### PR TITLE
feature: Add the ability to configure Redis

### DIFF
--- a/api-server/main.py
+++ b/api-server/main.py
@@ -18,6 +18,9 @@ from uuid import UUID
 
 myUUID = uuid.uuid4()
 
+redishost = os.environ.get('MB_REDIS_HOST', '127.0.0.1')
+redisport = os.environ.get('MB_REDIS_PORT', '6379')
+
 registration_key = "7bc78281-2036-41b2-8d98-fc23ec504e9a"
 
 uber1uuid = "bb4a84dc-cf4b-4d04-84fd-1c1cc8799e0d"
@@ -79,7 +82,7 @@ def check_intro_started():
 
 api_key_header = APIKeyHeader(name="X-API-Key")
 
-client = coredis.Redis(host='127.0.0.1', port=6379)
+client = coredis.Redis(host=redishost, port=redisport)
 
 class Admin(BaseModel):
     key: str

--- a/api-server/tests/test_badge.py
+++ b/api-server/tests/test_badge.py
@@ -4,6 +4,10 @@ from hrid import HRID
 import uuid
 import secrets
 import coredis
+import os
+
+redishost = os.environ.get('MB_REDIS_HOST', '127.0.0.1')
+redisport = os.environ.get('MB_REDIS_PORT', '6379')
 
 uberbadges = {
     "uber1": "bb4a84dc-cf4b-4d04-84fd-1c1cc8799e0d",
@@ -28,7 +32,7 @@ def generate_handle():
     handle = hruuid.generate()
     return handle
 
-client = coredis.Redis(host='127.0.0.1', port=6379)
+client = coredis.Redis(host=redishost, port=redisport)
 
 registration_key = "7bc78281-2036-41b2-8d98-fc23ec504e9a"
 handle = generate_handle()


### PR DESCRIPTION
This adds the ability to configure the Redis endpoint by following environment variables:
  - `MB_REDIS_HOST`
  - `MB_REDIS_PORT`

If the api server is instantiated without these values it will use the previous behavior of connecting to the default port (6369) on the default host (127.0.0.1).