### PR TITLE
Feature: Adding a self-hosted runner

### DIFF
--- a/.github/workflows/esp32-build-self-hosted.yml
+++ b/.github/workflows/esp32-build-self-hosted.yml
@@ -1,0 +1,86 @@
+name: Perform firmware build on the Intel NUC
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - 'main'
+    paths:
+      - 'board/**'
+      - 'badge/**'
+  push:
+    paths:
+      - '.github/workflows/esp32-build-self-hosted.yml'
+      - 'board/**'
+      - 'badge/**'
+
+jobs:
+  build:
+
+    runs-on: self-hosted
+
+    steps:
+    - name: Checkout MonkeyBadge
+      uses: actions/checkout@v4
+
+    - name: Unpack MicroPython
+      run: |
+         /usr/bin/tar zxf /opt/micropython.tgz
+
+#  Preferrable... but this takes almost 5 minutes to run
+#    - name: Checkout MicroPython
+#      run: |
+#         /usr/bin/git init micropython
+#         /usr/bin/git -C micropython remote add origin https://github.com/micropython/micropython
+#         /usr/bin/git -C micropython -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/master:refs/remotes/origin/master
+#         /usr/bin/git -C micropython checkout --progress --force -B master refs/remotes/origin/master
+#         /usr/bin/git -C micropython submodule sync --recursive
+#         /usr/bin/git -C micropython -c protocol.version=2 submodule update --init --force --depth=1 --recursive
+
+    - name: Set release date
+      run: |
+        echo "RELEASE_DATE=$(date +%Y-%m-%d.%s)" >> ${GITHUB_ENV}
+
+    - name: Fix partition path
+      run: |
+        ln -sf ${{ github.workspace }}/board/monkeybadge-partitions.csv ${{ github.workspace }}/micropython/ports/esp32/monkeybadge-partitions.csv
+
+    - name: Perform MicroPython Build
+      run: |
+        source /opt/espressif/esp-idf/export.sh
+        make -C micropython/ports/esp32 BOARD_DIR=${{ github.workspace}}/board BOARD=monkeybadge CONFIG_APP_PROJECT_VER=${{ env.RELEASE_DATE }} all
+
+    - name: Collect Assets
+      run: |
+        mkdir -p ${{ github.workspace }}/dist
+        cp ${{ github.workspace }}/micropython/ports/esp32/build-monkeybadge/firmware.bin ${{ github.workspace }}/dist/firmware_${{ env.RELEASE_DATE }}.bin
+        cp ${{ github.workspace }}/micropython/ports/esp32/build-monkeybadge/micropython.bin ${{ github.workspace }}/dist/ota_update_${{ env.RELEASE_DATE }}.bin
+        SHA256SUM=$(sha256sum ${{ github.workspace }}/dist/ota_update_${{ env.RELEASE_DATE }}.bin | awk '{print $1}')
+        FSIZE=$(find  -L * -name ota_update_${{ env.RELEASE_DATE }}.bin -printf '%s\n')
+        jq  -n --arg fsize "${FSIZE}" --arg sha "${SHA256SUM}" --arg fname ota_update_${{ env.RELEASE_DATE }}.bin '{"firmware": $fname, "sha": $sha, "length": $fsize}' | tee ${{ github.workspace}}/dist/ota_update_${{ env.RELEASE_DATE }}.json
+        echo "SHA256SUM=$SHA256SUM" | tee -a ${GITHUB_ENV}
+
+    - name: Upload Artifacts - Zip Bundle
+      uses: actions/upload-artifact@v3
+      with:
+        name: ota_update_${{ env.RELEASE_DATE }}
+        path: ${{ github.workspace }}/dist/**
+
+    - name: Upload Artifacts - Over the Air (OTA) binary update
+      uses: actions/upload-artifact@v3
+      with:
+        name: ota_update_${{ env.RELEASE_DATE }}.bin
+        path: ${{ github.workspace }}/dist/ota_update_${{ env.RELEASE_DATE }}.bin
+
+    - name: Upload Artifacts - OTA JSON Manifest
+      uses: actions/upload-artifact@v3
+      with:
+        name: ota_update_${{ env.RELEASE_DATE }}.json
+        path: ${{ github.workspace }}/dist/ota_update_${{ env.RELEASE_DATE }}.json
+
+    - name: Upload Artifacts - Full binary firmware
+      uses: actions/upload-artifact@v3
+      with:
+        name: firmware_${{ env.RELEASE_DATE }}.bin
+        path: ${{ github.workspace }}/dist/firmware_${{ env.RELEASE_DATE }}.bin


### PR DESCRIPTION
Adding a self-hosting runner for the purpose of the local build system.

We're not worried with overloading the system, so (for now) taking off some of the restrictions and allowing any changes to the GitHub workflows to trigger a build.

Previously using the basic GitHub action was taking over five minutes to complete.  I'm hoping this gets us under 30 seconds.  :fingers_crossed:

This cleans up some of the annotations in the workflow definition file including making it clear that it's running on the local server used for the conference.