### PR TITLE
bug: SI470X method rename (set_volume)

### DIFF
--- a/badge/library/radio.py
+++ b/badge/library/radio.py
@@ -143,7 +143,6 @@ class SI470X(object):
         i2c=None,
         i2c_addr=0x10,
         reset_pin=machine.Pin(16, machine.Pin.OUT),
-        tuning=None,
         band=BAND_US,
         channel_space=CSPACE_US,
         rds=False,
@@ -167,8 +166,6 @@ class SI470X(object):
         # Powerup sequence.
         self.reset()
         self.initialize()
-        if tuning:
-            self.tune(tuning)
 
     def waitAndFinishTune(self):
         c = 100
@@ -548,7 +545,7 @@ class SI470X(object):
         self.waitAndFinishTune()
 
     def changeVolume(self, delta):
-        self.set_volume(self.volume + delta)
+        self.setVolume(self.volume + delta)
 
     def mute(self):
         self.setVolume(0)


### PR DESCRIPTION
In a prior update to the MonkeyBadge class the method set_volume was renamed to setVolume().  This was discovered when performing a manual audit of the code base, as can be seen below:

```
>>> b.radio.changeVolume(12)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "library/radio.py", line 551, in changeVolume
AttributeError: 'SI470X' object has no attribute 'set_volume'
```

This commit both resolves the naming issue for the function of the class as well as removing an extraneous carriage return at the end of the file.  As such, we no longer need the "Tuning" property on the class nor the missing `tune()` function as called.