### PR TITLE
feature: added IR matching api endpoints

### DIFF
--- a/api-server/synthetic_badge_generator.py
+++ b/api-server/synthetic_badge_generator.py
@@ -3,8 +3,9 @@ import json
 import asyncio
 from uuid import uuid4
 from hrid import HRID
+from time import sleep
 
-
+TESTAPIKEY = "testapikey"
 templateJSON = """
 {
     "badgeHandle": "",
@@ -41,74 +42,98 @@ templateJSON = """
     }
 }
 """
+async def create_api_key(client, badge_id, api_key):
+        print(f"{badge_id} {api_key}")
+        apikeys = await client.lrange("badge_apikeys", 0, -1)
+
+        # search l for badge_id in bytes format
+        for i in apikeys:
+            if i.decode() == api_key:
+                return
+
+        # if api_key isn't in apikeys - then add it
+        await client.rpush("badge_apikeys", api_key.split())
 
 async def main():
     client = coredis.Redis(host='127.0.0.1', port='6379')
-
+    """
     # create 100 rando badges
     for i in range(1, 100):
         uuid = uuid4()
         j = json.loads(templateJSON)
-        hruuid=HRID(hridfmt=('adjective', 'noun'))
+        hruuid = HRID(hridfmt=('adjective', 'noun'))
         handle = hruuid.generate()
         j['badgeHandle'] = handle # create random handle
+        j['token'] = TESTAPIKEY
         await client.json.set(f"{uuid}", ".", j)
+        await create_api_key(client, uuid, TESTAPIKEY)
+    """
 
     # create top 5 badges
-
     # only Intro
     uuid = uuid4()
     j = json.loads(templateJSON)
-    hruuid=HRID(hridfmt=('adjective', 'noun'))
+    hruuid = HRID(hridfmt=('adjective', 'noun'))
     handle = hruuid.generate()
     j['badgeHandle'] = handle # create random handle
+    j['token'] = TESTAPIKEY
     j['intro']['complete'] = 1
     await client.json.set(f"{uuid}", ".", j)
+    await create_api_key(client, uuid, TESTAPIKEY)
 
     # Intro and Challenge 1
     uuid = uuid4()
     j = json.loads(templateJSON)
-    hruuid=HRID(hridfmt=('adjective', 'noun'))
+    hruuid = HRID(hridfmt=('adjective', 'noun'))
     handle = hruuid.generate()
     j['badgeHandle'] = handle # create random handle
+    j['token'] = TESTAPIKEY
     j['intro']['complete'] = 1
     j['challenge1']['complete'] = 1
     await client.json.set(f"{uuid}", ".", j)
+    await create_api_key(client, uuid, TESTAPIKEY)
+
 
     # Intro and Challenge 1 and Challenge 2
     uuid = uuid4()
     j = json.loads(templateJSON)
-    hruuid=HRID(hridfmt=('adjective', 'noun'))
+    hruuid = HRID(hridfmt=('adjective', 'noun'))
     handle = hruuid.generate()
     j['badgeHandle'] = handle # create random handle
+    j['token'] = TESTAPIKEY
     j['intro']['complete'] = 1
     j['challenge1']['complete'] = 1
     j['challenge2']['complete'] = 1
     j['challenge1']['matches'] = ['1', '2', '3', '4', '5']
     await client.json.set(f"{uuid}", ".", j)
+    await create_api_key(client, uuid, TESTAPIKEY)
 
     # Intro and Challenge 1 and Challenge 2 and matches
     uuid = uuid4()
     j = json.loads(templateJSON)
-    hruuid=HRID(hridfmt=('adjective', 'noun'))
+    hruuid = HRID(hridfmt=('adjective', 'noun'))
     handle = hruuid.generate()
     j['badgeHandle'] = handle # create random handle
+    j['token'] = TESTAPIKEY
     j['intro']['complete'] = 1
     j['challenge1']['complete'] = 1
     j['challenge2']['complete'] = 1
     j['challenge1']['matches'] = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']
     await client.json.set(f"{uuid}", ".", j)
+    await create_api_key(client, uuid, TESTAPIKEY)
 
     uuid = uuid4()
     j = json.loads(templateJSON)
-    hruuid=HRID(hridfmt=('adjective', 'noun'))
+    hruuid = HRID(hridfmt=('adjective', 'noun'))
     handle = hruuid.generate()
     j['badgeHandle'] = handle # create random handle
+    j['token'] = TESTAPIKEY
     j['intro']['complete'] = 1
     j['challenge1']['complete'] = 1
     j['challenge2']['complete'] = 1
     j['challenge3']['complete'] = 1
     j['challenge1']['matches'] = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11']
     await client.json.set(f"{uuid}", ".", j)
+    await create_api_key(client, uuid, TESTAPIKEY)
 
 asyncio.run(main())


### PR DESCRIPTION
Added 2 new endpoints for IR matching:

- friendrequest:  checks to see if the IRID submitted is in the redis datastore. if the IRID exists, the server will add the badgehandle and uuid of the remote badge to the matches list.

- getIRID: generates a unique IRID (16bit) address, saves it to the redis datastore as a key/value pair (IRID:UUID), also adds to the game state for UUID.

Cleaned up duplicative BaseModel struct classes.

changehandle API now requires an apitoken.

updated the synthetic badge generator to have a generic api token to make testing the API server easier. 