### PR TITLE
chore: Adding the Python linter `ruff`

### DIFF
--- a/.github/workflows/python_lint_format.yml
+++ b/.github/workflows/python_lint_format.yml
@@ -1,0 +1,22 @@
+name: Python code linting and formatting
+on:
+  workflow_call:
+
+  push:
+    paths: 
+      - 'board/**'
+      - 'badge/**'
+  pull_request:
+    paths: 
+      - 'board/**'
+      - 'badge/**'
+
+jobs:
+  mpy_lint:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - run: pip install --user ruff=0.1.6
+      - run: ruff check --output-format=github badge
+      - run: ruff format --diff badge
+


### PR DESCRIPTION
I was going to set this up with Black, but saw that MicroPython has migrated over to using `ruff` (https://github.com/astral-sh/ruff)