### PR TITLE
bug: Remove bare except calls

### DIFF
--- a/badge/config.py
+++ b/badge/config.py
@@ -21,7 +21,7 @@ def getNVS(key, size):
 def eraseNVS(key):
     try:
         nvs.erase_key(key)
-    except:
+    except Exception:
         # TODO: if we don't mask this users will likely see they can modify the value "API_SERVER"
         # pass
         print("Unable to erase key {}".format(key))
@@ -29,17 +29,17 @@ def eraseNVS(key):
 # Wifi Config
 try:
     WIFI_SSID = getNVS("WIFI_SSID", 32)
-except:
+except Exception:
     pass
 
 try:
     WIFI_PASSWORD = getNVS("WIFI_PASSWORD", 63)
-except:
+except Exception:
     pass
 
 try:
     API_SERVER = getNVS("API_SERVER", 255)
-except:
+except Exception:
     pass
 
 RESET_URL = "https://update.kafka.tel/firmware/reset.json"

--- a/badge/library/monkeybadge.py
+++ b/badge/library/monkeybadge.py
@@ -72,7 +72,7 @@ class MonkeyBadge:
         # Need to pull these from the db store.
         try:
             self.apitoken = self.db.get("token")
-        except:
+        except Exception:
             print("Unable to load token: badge not registered.")
             self.apitoken = None
 
@@ -372,7 +372,7 @@ class MonkeyBadge:
         """
         try:
             current_state = json.loads(self.db.get("state"))
-        except:
+        except Exception:
             print("Unable to load saved state: not found.")
             current_state = ""
         # print(f"Current State {type(current_state)}: {current_state}")


### PR DESCRIPTION
The `pydocstyle` linter defines `E722` for the use of a bare `except` statement.  As per the `ruff` linter's documentation:

> # bare-except (E722)
>
> Derived from the pycodestyle linter.
>
> ## What it does
>
> Checks for bare except catches in try-except statements.
>
> ## Why is this bad?
>
> A bare except catches BaseException which includes KeyboardInterrupt,
> SystemExit, Exception, and others. Catching BaseException can make it
> hard to interrupt the program (e.g., with Ctrl-C) and can disguise other
> problems.

This removes bare calls which were used in both `config.py` and `library/monkeybadge.py` and replaces them eith `Exception` which will still catch most exceptions but ignore some system exceptions.