### PR TITLE
nit: Removing unused `err` in Exception

### DIFF
--- a/badge/library/monkeybadge.py
+++ b/badge/library/monkeybadge.py
@@ -606,7 +606,7 @@ class MonkeyBadge:
                     print(".")
                     self.checkin()
                     self.last_checkin = now
-                except Exception as err:
+                except Exception:
                     pass
 
             # update ir status


### PR DESCRIPTION
In `badge/library/monkeybadge.py` there was a single unused `err` variable which was not caught in other linting change sets.