### PR TITLE
chore: Clean up Ruff linting / formatting

### DIFF
--- a/.github/workflows/python_lint_format.yml
+++ b/.github/workflows/python_lint_format.yml
@@ -2,9 +2,11 @@ name: Python code linting and formatting
 on:
   push:
     paths: 
+      - 'api-server/**'
       - 'badge/**'
   pull_request:
     paths: 
+      - 'api-server/**'
       - 'badge/**'
   workflow_dispatch:
 
@@ -14,6 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: pip install ruff==0.1.6
+        name: Install ruff
       - run: ruff check --output-format=github badge
+        name: Perform linting of code base using ruff
       - run: ruff format --diff badge
+        name: Check to see if code has been formatted with ruff
 

--- a/.gitignore
+++ b/.gitignore
@@ -153,6 +153,9 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# Ruff Cache
+.ruff_cache
+
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/badge/library/radio.py
+++ b/badge/library/radio.py
@@ -193,6 +193,7 @@ class SI470X(object):
         # variable name solely within the scope of the function.
 
         sf = self.fields
+        # fmt: off
         print(
 "   DEVICEID PN      : (0x{:0x}".format(sf.DEVICEID.PN) + f") \t{sf.DEVICEID.PN}\n" +
 "   DEVICEID MFGID   : (0x{:0x}".format(sf.DEVICEID.MFGID) + f") \t{sf.DEVICEID.MFGID}\n" +
@@ -228,6 +229,7 @@ class SI470X(object):
 " SYSCONFIG3 VOLEXT  : (0x{:0x}".format(sf.SYSCONFIG3.VOLEXT) + f") \t{sf.SYSCONFIG3.VOLEXT}\n" +
 " SYSCONFIG3 SKSNR   : (0x{:0x}".format(sf.SYSCONFIG3.SKSNR) + f") \t{sf.SYSCONFIG3.SKSNR}\n" +
 " SYSCONFIG3 SKCNT   : (0x{:0x}".format(sf.SYSCONFIG3.SKCNT) + f") \t{sf.SYSCONFIG3.SKCNT}\n")
+# fmt: on
 
 
     def setRegion(self):


### PR DESCRIPTION
This adds the `.ruff_cache` directory to `.gitignore`, adds the api-server to the scanned code paths, and disables Ruff formatting around the I2C status table for the Si470x radio.