### PR TITLE
dependency: Add mpy implementation of logging

### DIFF
--- a/board/manifest.py
+++ b/board/manifest.py
@@ -6,6 +6,7 @@ include("$(MPY_DIR)/extmod/asyncio")
 require("bundle-networking")
 
 # Require some micropython-lib modules.
+require("logging")
 require("neopixel")
 require("ssd1306")
 require("umqtt.robust")


### PR DESCRIPTION
We've added in the `logging` module (ported from CPython to MicroPython) to support the debug infrastructure.