### PR TITLE
feature: SHA hash of running partition

### DIFF
--- a/badge/boot.py
+++ b/badge/boot.py
@@ -25,9 +25,11 @@ async def connect_to_wifi(ssid, password):
 
 async def check_ota():
     # TODO: Set this to false before shipping
-
-    with OTA(verbose=True) as ota:
-        ota.from_json(config.UPDATE_URL)
+    try:
+        with OTA(verbose=True) as ota:
+            ota.from_json(config.UPDATE_URL)
+    except Exception:
+        pass
 
 
 print("Performing POST")


### PR DESCRIPTION
This adds a new method "check_self_sha" to the OTA object.  From there this method is utilized when checking verifying the desired versus expected firmware state as expressed via JSON metadata.

If the hash of the running firmware matches the hash as provided by the remote server there's not even a point in downloading the binary file.