### PR TITLE
fix: Removing unused menu items.

### DIFF
--- a/badge/library/monkeybadge.py
+++ b/badge/library/monkeybadge.py
@@ -208,9 +208,6 @@ class MonkeyBadge:
             [
                 MenuItem("Battery Life", self.battery_check),
                 MenuItem("OLED Brightness", submenu=self.oled_brightness_menu),
-                MenuItem("LED Brightness", "pass"),
-                #        MenuItem("Volume", "pass"),
-                MenuItem("Debounce", "pass"),
                 MenuItem("OTA Update", self.update_badge),
                 MenuItem("Reset Badge", self.reset_badge),
             ]


### PR DESCRIPTION
Removed the LED Brightness global setting menu since we're not setting that. Also removed the Debounce menu. I also removed a superfluous comment in the menu, it was old unused code, already moved the volume to the radio settings.
Tested on the badge with the latest firmware, good to go.