### PR TITLE
bug: if a badge does checkin and the server has lost the data, the badge is stuck

### DIFF
--- a/badge/library/gameclient.py
+++ b/badge/library/gameclient.py
@@ -49,10 +49,10 @@ class GameClient:
             j = r.json()
             r.close()
             return j
-
-        # return the server's reponse or error message
-        r.close()
-        print(f"Error registering badge: {r.text}")
+        else:
+            print(f"Error Registering badge: {r.text}")
+            r.close()
+            return None
 
     def checkin(self, apitoken, uuid):
         """
@@ -63,16 +63,16 @@ class GameClient:
 
         request_body = {"myUUID": uuid}
 
-        try:
-            sc, j = self.secure_api_request(request_url, apitoken, request_body)
-        except Exception as err:
-            print(f"Error reaching {self.baseurl}/checkin: {err}")
-            return None
+        sc, j = self.secure_api_request(request_url, apitoken, request_body)
 
-        if sc == 200:
-            return j
+        print(f"Checkin returned {sc}, {j}")
+        if sc == 404:
+            return 404, None
+        elif sc == 200:
+            return 200, j
 
-        return None
+        print(f"Error reaching {self.baseurl}/checkin.")
+        return 500, None
 
     def konami_complete(self, token, uuid):
         request_url = self.baseurl + "/introcomplete"
@@ -91,7 +91,7 @@ class GameClient:
         request_body = {"myUUID": uuid, "remoteIRID": str(IRID)}
 
         sc, j = self.secure_api_request(request_url, token, request_body)
-
+        print(f"Friend Request returned {sc}, {j}")
         if sc == 200:
             return j
         elif sc == 400:
@@ -109,10 +109,11 @@ class GameClient:
         print(f"header: {header}\n body: {json}")
 
         r = requests.post(url, headers=header, json=json)
-        if r.status_code == 200:
+        sc = r.status_code
+        if sc == 200:
             j = r.json()
             r.close()
-            return 200, j
+            return sc, j
 
         r.close()
-        return r.status_code(), None
+        return sc, None

--- a/badge/library/konami.py
+++ b/badge/library/konami.py
@@ -372,7 +372,7 @@ class Konami:
 def main():
     """Entry function"""
     np = neopixel.NeoPixel(machine.Pin(18), 7)
-    print("starting konami mode")
+    print("starting intro mode")
     k = Konami()
     while True:
         do_heartbeat(np)


### PR DESCRIPTION
In the situation where a badge's redis key is lost, the badge is unusable.

note: IF the badge loses it's API token, and the server had a key in redis, the player will need to ask us for the key.

to fix this, I added a check for a 404 from checkin on the apiserver, if the badge receives a 404 - that means the badge doesnt exist.

the badge will try to re-register with the current API token. If the token exists in the api-keys table, it's ignored, otherwise it will be added as well.

I also changed the initial last_checkin value to -61000 to ensure we checkin on the first event loop.

Also made a quick change to konami.py, changed the print statement from konami to intro.