### PR TITLE
bug: Introduced a better battery meter

### DIFF
--- a/badge/library/battery.py
+++ b/badge/library/battery.py
@@ -1,6 +1,7 @@
 from machine import Pin, ADC
 import config
 
+
 class Meter:
     def __init__(
         self,


### PR DESCRIPTION
Ripped out the old battery logic. This Meter class still returns a formatted percentage, but it's way more accurate.

I take the max measured adc value of 2404 with my best battery and call that 100%. If the adc value is greater than or equal to 2404, the percentage gets set to 100%, if it's less than or equal to 1500, it sets it to 0%. Anything in between is broken down into a percentage and returned.

A power bar and a percentage is still printed to the console.