### PR TITLE
feature: rate limiting for ch2/3

### DIFF
--- a/api-server/requirements.txt
+++ b/api-server/requirements.txt
@@ -3,3 +3,4 @@ hrid
 coredis 
 requests
 uuid
+slowapi


### PR DESCRIPTION
Due to rampant abuse in ch1, I have implemented rate limiting in the remaining challenges. :evilgrin:

using slowapi module, I have implemented a 10req /min rule for endpoints: /hiddenobject and /monkeysee.
 